### PR TITLE
fix: server not starting with default settings // typo in config.json.prod

### DIFF
--- a/server/app/config.json.prod
+++ b/server/app/config.json.prod
@@ -6,10 +6,10 @@
       "port": 8888,
       "sslInsecureSkipVerify": false
     },
-    "listen_port": PROXY_LISTEN_PORT
+    "listen_port": "PROXY_LISTEN_PORT"
   },
   "filesystem": {
-      "listen_port": FILESYSTEM_LISTEN_PORT
+      "listen_port": "FILESYSTEM_LISTEN_PORT"
   },
   "process": {
     "nb_forks": "PROCESS_NB_FORKS"


### PR DESCRIPTION
When starting tatwebui server with default config, I got this error message:

```
################
S.T.A.R.T.I.N.G
################

module.js:485
    throw err;
          ^
SyntaxError: /tat/dist/app/config.json: Unexpected token P
    at Object.parse (native)
    at Object.Module._extensions..json (module.js:482:27)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at /tat/dist/index.js:8:16
    at Object.<anonymous> (/tat/dist/index.js:86:3)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
```
